### PR TITLE
Fix quick start guide app init wording

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -36,7 +36,7 @@ from holm import App
 app = App()
 ```
 
-This is all you need! The `App()` call will automatically discover and register all your layouts and pages based on the file structure.
+This is all you need! The `App()` call will automatically discover and register all your layouts and pages based on the folder structure.
 
 ## Create a root layout
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Quick Start Guide to clarify that App() discovers and registers layouts/pages based on the folder structure, not individual files.
  - Improved wording for clearer guidance on project organization and discovery behavior.
  - No functional changes; content aligns documentation with current behavior to reduce confusion for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->