### PR TITLE
Just log module import errors, skip folders whose name starts with a dot

### DIFF
--- a/holm/__init__.py
+++ b/holm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .app import App as App
 from .fastapi import FastAPIDependency as FastAPIDependency

--- a/holm/_model.py
+++ b/holm/_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from importlib import import_module
@@ -137,7 +138,13 @@ class PackageInfo:
 
         # Support applications that are not wrapped in a Python package.
         # In that case `self.package_name` is ".".
-        module = import_module(name if self.package_name == "." else f"{self.package_name}.{name}")
+        import_name = name if self.package_name == "." else f"{self.package_name}.{name}"
+        try:
+            module = import_module(import_name)
+        except Exception:
+            # Handle potential misconfigurations with a simple warning, instead of an exception.
+            logging.getLogger("holm").warning(f"Failed to import module {name} at: {import_name}")
+            return None
 
         if not validate(module):
             raise ValueError(f"Invalid module: {name}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes during module loading by logging warnings on failed imports and continuing processing.
  * Improves project scanning to correctly ignore hidden and tooling directories (e.g., dot-prefixed, VCS/venv), reducing false positives.
  * Uses project-root–relative paths for filtering, leading to more accurate discovery.

* **Chores**
  * Bumped version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->