### PR TITLE
chore: remove duplicate `jinja2` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "fastapi>=0.135.0",
     "fasthx>=3.2.2",
     "htmy[jinja,lxml]>=0.13.1",
-    "jinja2>=3.1.6",
     "markupsafe>=3.0.3",
     "python-multipart>=0.0.20",
 ]


### PR DESCRIPTION
Depending on `htmy[jinja]` already pulls the right `jinja2` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an explicitly declared Jinja2 dependency from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->