### PR TITLE
docs: complement one-line docstrings in core modules with Args/Returns

### DIFF
--- a/holm/_model.py
+++ b/holm/_model.py
@@ -70,7 +70,10 @@ class AppConfig:
     """
 
     def add_to_default_context(self, context: Context) -> None:
-        """Merges the given context into the app-scope default context."""
+        """Merges the given context into the app-scope default context.
+
+        Args:
+            context: The context to merge into the default context."""
         self.default_context.update(context)
 
     @classmethod
@@ -195,9 +198,14 @@ class PackageInfo:
 
     @classmethod
     def from_marker_file(cls, file_path: Path, *, config: AppConfig) -> PackageInfo:
-        """
-        Creates a `PackageInfo` instance from a so called "marker" that is located in the package.
-        """
+        """Creates a `PackageInfo` instance from a so called "marker" that is located in the package.
+
+        Args:
+            file_path: Path of the marker file.
+            config: Application configuration used to resolve the root directory.
+
+        Returns:
+            The `PackageInfo` instance created from the marker file."""
         package_dir = file_path.relative_to(config.root_dir).parent
         package_dir_str = "/".join(package_dir.parts)
         package_name = package_dir_str.replace("/", ".")

--- a/holm/app.py
+++ b/holm/app.py
@@ -231,7 +231,13 @@ def _discover_app_packages(config: AppConfig) -> set[PackageInfo]:
 
     @lru_cache()
     def is_excluded(path: Path) -> bool:
-        """Returns whether the given file or package path should be excluded from the application."""
+        """Returns whether the given file or package path should be excluded from the application.
+
+    Args:
+        path: The file or package path to check.
+
+    Returns:
+        `True` if the path should be excluded, `False` otherwise."""
         return any(
             # Exclude if a path segment starts with an underscore but does not end with one.
             # Path segments that both start and end with an underscore represent path parameters!

--- a/holm/module_options/_actions.py
+++ b/holm/module_options/_actions.py
@@ -69,9 +69,13 @@ def get_actions(obj: Any) -> ActionDescriptors | None:
 
 
 def has_actions(obj: Any) -> TypeGuard[Any]:
-    """
-    "Type guard" that returns `True` if the given object contains actions.
-    """
+    """"Type guard" that returns `True` if the given object contains actions.
+
+    Args:
+        obj: The object to check for actions.
+
+    Returns:
+        `True` if the object contains actions, `False` otherwise."""
     return bool(get_actions(obj))
 
 

--- a/holm/module_options/_metadata.py
+++ b/holm/module_options/_metadata.py
@@ -41,9 +41,10 @@ def get_metadata_dependency(obj: Any) -> MetadataDependency:
 
 
 def empty_metadata_dep() -> None:
-    """
-    Metadata dependency that returns `None`.
-    """
+    """Metadata dependency that returns `None`.
+
+    Returns:
+        The metadata dependency that always returns `None`."""
     return None
 
 
@@ -74,7 +75,14 @@ class Metadata(ContextAware):
     def get(self, key: Any, default: Any) -> Any: ...
 
     def get(self, key: Any, default: Any | None = None) -> Any | None:
-        """Implements `Mapping.get()`."""
+        """Implements `Mapping.get()`.
+
+        Args:
+            key: Key to look up in the metadata.
+            default: Value to return if the key is not present.
+
+        Returns:
+            The value for `key` if present, `default` otherwise."""
         return self._metadata.get(key, default)
 
     def __contains__(self, key: Any) -> bool:
@@ -100,13 +108,22 @@ class Metadata(ContextAware):
         return not self.__eq__(other)
 
     def items(self) -> ItemsView[Any, Any]:
-        """Implements `Mapping.items()`."""
+        """Implements `Mapping.items()`.
+
+        Returns:
+            View of the metadata items."""
         return self._metadata.items()
 
     def keys(self) -> KeysView[Any]:
-        """Implements `Mapping.keys()`."""
+        """Implements `Mapping.keys()`.
+
+        Returns:
+            View of the metadata keys."""
         return self._metadata.keys()
 
     def values(self) -> ValuesView[Any]:
-        """Implements `Mapping.values()`."""
+        """Implements `Mapping.values()`.
+
+        Returns:
+            View of the metadata values."""
         return self._metadata.values()

--- a/holm/modules/_api.py
+++ b/holm/modules/_api.py
@@ -21,7 +21,13 @@ class APIDefinition(Protocol):
 
 
 def is_api_definition(obj: Any) -> TypeGuard[APIDefinition]:
-    """Type guard for `APIDefinition`."""
+    """Type guard for `APIDefinition`.
+
+    Args:
+        obj: The object to check.
+
+    Returns:
+        `True` if the object defines an API, `False` otherwise."""
     api = getattr(obj, "api", None)
     # APIRouter is also callable, so callable(api) would be enough,
     # but let's be a bit more thorough in this case.

--- a/holm/modules/_error.py
+++ b/holm/modules/_error.py
@@ -30,7 +30,13 @@ class ErrorHandlerOwner(Protocol):
 
 
 def is_error_handler_owner(obj: Any) -> TypeGuard[ErrorHandlerOwner]:
-    """Type guard for `ErrorHandlerOwner`."""
+    """Type guard for `ErrorHandlerOwner`.
+
+    Args:
+        obj: The object to check.
+
+    Returns:
+        `True` if the object owns error handlers, `False` otherwise."""
     handlers = getattr(obj, "handlers", None)
     return handlers is not None and (isinstance(handlers, Mapping) or callable(handlers))
 
@@ -73,9 +79,14 @@ def register_error_handlers(app: FastAPI, owner: ErrorHandlerOwner | None, *, ht
 
 
 def wrap_error_handler(error_handler: FastAPIErrorHandler, htmy: HTMY) -> FastAPIErrorHandler:
-    """
-    Wraps the given error handler in a function that automatically renders `htmy` `Component` return values.
-    """
+    """Wraps the given error handler in a function that automatically renders `htmy` `Component` return values.
+
+    Args:
+        error_handler: The error handler to wrap.
+        htmy: The `HTMY` renderer instance.
+
+    Returns:
+        A wrapped error handler that renders `htmy` components."""
 
     async def rendering_error_handler_wrapper(request: Request, error: Exception) -> Response:
         result = await error_handler(request, error)

--- a/holm/modules/_layout.py
+++ b/holm/modules/_layout.py
@@ -37,7 +37,13 @@ class CustomLayoutDefinition:
 
 
 def is_layout_definition(obj: Any) -> TypeGuard[LayoutDefinition]:
-    """Type guard for `LayoutDefinition`."""
+    """Type guard for `LayoutDefinition`.
+
+    Args:
+        obj: The object to check.
+
+    Returns:
+        `True` if the object defines a layout, `False` otherwise."""
     layout = getattr(obj, "layout", None)
     return callable(layout)
 
@@ -104,21 +110,32 @@ def combine_layouts_to_dependency(
 
 
 def empty_layout(props: Any) -> Any:
-    """`LayoutFactory` that simply returns the received props."""
+    """`LayoutFactory` that simply returns the received props.
+
+    Args:
+        props: The props to return.
+
+    Returns:
+        The received props unchanged."""
     return props
 
 
 def empty_layout_dependency() -> FastAPIDependency[LayoutFactory]:
-    """
-    FastAPI dependency that returns `empty_layout`.
-    """
+    """FastAPI dependency that returns `empty_layout`.
+
+    Returns:
+        The `empty_layout` layout factory."""
     return empty_layout
 
 
 def layout_to_dependency(layout: Layout) -> FastAPIDependency[LayoutFactory]:
-    """
-    Converts a layout to a FastAPI dependency that returns a layout factory.
-    """
+    """Converts a layout to a FastAPI dependency that returns a layout factory.
+
+    Args:
+        layout: The layout to convert.
+
+    Returns:
+        A FastAPI dependency returning a layout factory."""
     # eval_str=True is necessary in case future __annotations__ is used
     # where the layout is function is defined.
     params = tuple(inspect.signature(layout, eval_str=True).parameters.values())

--- a/holm/modules/_page.py
+++ b/holm/modules/_page.py
@@ -26,6 +26,12 @@ class PageDefinition(Protocol):
 
 
 def is_page_definition(obj: Any) -> TypeGuard[PageDefinition]:
-    """Type guard for `PageDefinition`."""
+    """Type guard for `PageDefinition`.
+
+    Args:
+        obj: The object to check.
+
+    Returns:
+        `True` if the object defines a page, `False` otherwise."""
     page = getattr(obj, "page", None)
     return callable(page)


### PR DESCRIPTION
## Summary

Extends the one-line docstrings of 17 core public functions/methods with `Args`/`Returns` sections so that the mkdocstrings-rendered API pages show consistent parameter/return documentation.

Covered (all in `holm/` core, examples untouched):
- `_model.py`: `AppConfig.add_to_default_context`, `PackageInfo.from_marker_file`
- `app.py`: `is_excluded`
- `module_options/_actions.py`: `has_actions`
- `module_options/_metadata.py`: `Metadata.get/items/keys/values`, `empty_metadata_dep`
- `modules/_error.py`: `is_error_handler_owner`, `wrap_error_handler`
- `modules/_layout.py`: type guard + layout helpers
- `modules/_page.py`: `is_page_definition`
- `modules/_api.py`: `is_api_definition`

## Validation
- Docstring-only change: zero behavior impact (`py_compile` passes on all touched modules)
- Original first lines preserved verbatim; only sections added

Docs-only, low risk. Happy to adjust wording to your preferred style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded API documentation across configuration, package discovery, metadata, module definitions, layouts, pages, and error handling.
  - Added clearer descriptions of parameters, return values, and behavior.
  - Standardized docstrings to a structured format for improved readability and maintainability.
  - No functional behavior or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->